### PR TITLE
👷 ci: clean rustup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
     name: Ubuntu, ${{ matrix.target }}. ${{ matrix.build_type }}
     steps:
       - uses: actions/checkout@v4
-      - name: update cargo to 1.80.0
-        run: rustup update
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/lint-and-fmt.yml
+++ b/.github/workflows/lint-and-fmt.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: update cargo to 1.80.0
-        run: rustup update
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/TODO.md
+++ b/TODO.md
@@ -1,1 +1,0 @@
-补充`check_access`, 在`create`、`opendir(这个没实现)`、`open`、`rename`、`rmdir`、`unlink`、`mkdir`、`mknod(没实现)`、`setattr`、`lookup`、`insert_link(没实现)`、`mknod(没实现)`、`symlink(没实现)`中使用


### PR DESCRIPTION
## feat
* GitHub Actions 已经支持了 rust 1.80.0, 所以删除更新配置